### PR TITLE
Fix Windows cross-compile by linking rpcrt4

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -15,7 +15,7 @@ LDFLAGS = -L$(MINGW_PREFIX)/lib \
           -lmingw32 -lSDL2main -lSDL2 -lSDL2_ttf -lSDL2_mixer \
           -ljansson -lcurl -lbcrypt -lpthread -lws2_32 -lcrypt32 \
           -lwldap32 -lgdi32 -lwinmm -limm32 -lole32 \
-          -loleaut32 -lversion -lsetupapi -lm -mwindows -static
+          -loleaut32 -lversion -lsetupapi -lrpcrt4 -lm -mwindows -static
 
 all: $(TARGET)
 


### PR DESCRIPTION
## Summary
- link `rpcrt4` when cross-compiling for Windows to resolve `UuidCreate`

## Testing
- `make -f Makefile.win`


------
https://chatgpt.com/codex/tasks/task_e_68b7f8167ec08326a92aa4ba686de0a2