### PR TITLE
Add workflow to build and release Windows executable

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,76 @@
+name: Build and Release Windows Executable
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up cross-compilation environment
+        run: |
+          set -euxo pipefail
+          apt-get update
+          apt-get install -y \
+              build-essential make gcc g++ pkg-config \
+              mingw-w64 \
+              libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
+              libcurl4-openssl-dev \
+              ca-certificates git wget xxd unzip wine
+
+          cd /tmp
+          echo "== Preparing Windows cross-compile SDL2 core =="
+          wget -q https://github.com/libsdl-org/SDL/releases/download/release-2.30.4/SDL2-2.30.4.tar.gz
+          tar -xzf SDL2-2.30.4.tar.gz
+          cd SDL2-2.30.4
+          ./configure --host=x86_64-w64-mingw32 --prefix=/usr/x86_64-w64-mingw32
+          make -j"$(nproc)"
+          make install
+          cd /tmp
+
+          echo "== Installing SDL2_image, SDL2_mixer, SDL2_ttf for MinGW =="
+          wget -q https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.2/SDL2_image-devel-2.8.2-mingw.tar.gz
+          wget -q https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-devel-2.8.1-mingw.tar.gz
+          wget -q https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.22.0/SDL2_ttf-devel-2.22.0-mingw.tar.gz
+
+          for a in *.tar.gz; do
+              tar -xzf "$a"
+          done
+
+          cp -r SDL2_image*/x86_64-w64-mingw32/* /usr/x86_64-w64-mingw32/ || true
+          cp -r SDL2_mixer*/x86_64-w64-mingw32/* /usr/x86_64-w64-mingw32/ || true
+          cp -r SDL2_ttf*/x86_64-w64-mingw32/* /usr/x86_64-w64-mingw32/ || true
+
+          echo "== Building static libcurl for MinGW =="
+          wget -q https://curl.se/download/curl-8.8.0.tar.gz
+          tar -xzf curl-8.8.0.tar.gz
+          cd curl-8.8.0
+          ./configure --host=x86_64-w64-mingw32 --prefix=/usr/x86_64-w64-mingw32 \
+            --with-schannel --disable-shared --enable-static --disable-ldap --disable-ldaps
+          make -j"$(nproc)"
+          make install
+
+          echo "== Building Jansson for MinGW =="
+          cd /tmp
+          wget -q https://github.com/akheron/jansson/releases/download/v2.14/jansson-2.14.tar.gz
+          tar -xzf jansson-2.14.tar.gz
+          cd jansson-2.14
+          ./configure --host=x86_64-w64-mingw32 \
+                      --prefix=/usr/x86_64-w64-mingw32 \
+                      --disable-shared --enable-static
+          make -j"$(nproc)"
+          make install
+
+      - name: Build Windows executable
+        run: make -f Makefile.win
+
+      - name: Upload executable to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: radar_display.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that cross-compiles and uploads a Windows executable on tagged releases

## Testing
- `make -f Makefile.win`

------
https://chatgpt.com/codex/tasks/task_e_68b82be38c1c832697b6609099732f0c