### PR TITLE
Document Windows cross-compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # radar1090
+
+Simple radar display application built with SDL2.
+
+## Building on Linux
+
+Ensure development packages for SDL2, SDL2_ttf, SDL2_mixer, libcurl, and jansson are installed.
+
+```
+make
+```
+
+This produces `./radar_display`.
+
+## Building for Windows (cross-compiled from Linux)
+
+A `Makefile.win` is provided for generating a Windows executable using the mingw-w64 toolchain.
+Install the SDL2, SDL2_ttf, SDL2_mixer, libcurl, and jansson libraries for your MinGW environment,
+then run:
+
+```
+make -f Makefile.win
+```
+
+The resulting `radar_display.exe` will be placed in the project root.
+
+To remove built binaries, use `make clean` or `make -f Makefile.win clean`.
+


### PR DESCRIPTION
## Summary
- add README instructions for building on Linux
- document Windows cross-compilation using Makefile.win

## Testing
- `make clean && make` *(fails: fatal error: jansson.h: No such file or directory)*
- `make -f Makefile.win clean && make -f Makefile.win`


------
https://chatgpt.com/codex/tasks/task_e_68b8332745548326bf2bbf2eefec3a79