### PR TITLE
Add inbound aircraft alert overlay

### DIFF
--- a/config.h
+++ b/config.h
@@ -13,6 +13,9 @@
 #define DUMP1090_SERVER "192.168.50.100" // IP or hostname of dump1090 server
 #define DUMP1090_PORT 8080               // The default web port for dump1090 is often 8080
 
+// -- Alert Settings --
+#define INBOUND_ALERT_DISTANCE_KM 5.0    // Threshold distance for inbound aircraft alerts
+
 // I2S pins for MAX98357A audio output
 #define I2S_BCLK_PIN  17
 #define I2S_LRCLK_PIN 16

--- a/main.c
+++ b/main.c
@@ -567,6 +567,11 @@ int main(int argc, char* argv[]) {
         SDL_Color accent = COLOR_RADAR;
         SDL_Color alert = COLOR_ALERT;
 
+        if (displayAlert && currentTime < displayTimeout) {
+            drawText(renderer, font, displayMessage, 20, text_y, alert, false);
+            text_y += 35;
+        }
+
         if (lastPingedAircraft.isValid) {
             snprintf(buffer, sizeof(buffer), "Flt: %s", strlen(lastPingedAircraft.flight) > 0 ? lastPingedAircraft.flight : "------");
             drawText(renderer, font, buffer, 20, text_y, textColor, false); text_y += 35;
@@ -623,15 +628,14 @@ int main(int argc, char* argv[]) {
         SDL_SetRenderDrawColor(renderer, accent.r, accent.g, accent.b, accent.a);
 
         // Display Overlay
-        if (currentTime < displayTimeout) {
+        if (currentTime < displayTimeout && !displayAlert) {
             SDL_Rect bg = {SCREEN_WIDTH/2 - 175, SCREEN_HEIGHT/2 - 40, 350, 80};
             SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
             SDL_SetRenderDrawColor(renderer, COLOR_OVERLAY_BG.r, COLOR_OVERLAY_BG.g, COLOR_OVERLAY_BG.b, COLOR_OVERLAY_BG.a);
             SDL_RenderFillRect(renderer, &bg);
             SDL_SetRenderDrawColor(renderer, accent.r, accent.g, accent.b, accent.a);
             SDL_RenderDrawRect(renderer, &bg);
-            SDL_Color overlayColor = displayAlert ? alert : textColor;
-            drawText(renderer, font, displayMessage, SCREEN_WIDTH/2, bg.y + 25, overlayColor, true);
+            drawText(renderer, font, displayMessage, SCREEN_WIDTH/2, bg.y + 25, textColor, true);
         }
 
         SDL_RenderPresent(renderer);

--- a/main.c
+++ b/main.c
@@ -528,7 +528,7 @@ int main(int argc, char* argv[]) {
             if (diff > 180.0) diff = 360.0 - diff;
             if (diff < 90.0) {
                 double minDist = trackedAircraft[i].distanceKm * sin(deg2rad(diff));
-                if (minDist <= 5.0) {
+                if (minDist <= INBOUND_ALERT_DISTANCE_KM) {
                     inboundFound = true;
                     snprintf(displayMessage, sizeof(displayMessage), "Inbound alert: %s",
                              strlen(trackedAircraft[i].flight) > 0 ? trackedAircraft[i].flight : trackedAircraft[i].hex);


### PR DESCRIPTION
## Summary
- Detect aircraft on a trajectory within 5 km of base and trigger an alert message.
- Highlight alert messages in red for better visibility.

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68bdbb8cfd74832681e177b47e8363cf